### PR TITLE
feat: hide days outside min/max date interval

### DIFF
--- a/docsRNC/docs/Components/Calendar.md
+++ b/docsRNC/docs/Components/Calendar.md
@@ -70,6 +70,11 @@ Whether to show weeks numbers
 Whether to hide days of other months in the month page  
 <span style={{color: 'grey'}}>boolean</span>
 
+### hideDaysOutOfInterval
+
+Whether to hide days outside of the min/max date interval  
+<span style={{color: 'grey'}}>boolean</span>
+
 ### showSixWeeks
 
 Whether to always show six weeks on each month (when hideExtraDays = false)  

--- a/example/src/screens/calendarScreen.tsx
+++ b/example/src/screens/calendarScreen.tsx
@@ -75,6 +75,22 @@ const CalendarScreen = () => {
     );
   };
 
+  const renderCalendarWithDaysOutsideIntervalHidden = () => {
+    return (
+      <Fragment>
+        <Text style={styles.text}>Calendar with days outside min/max date hidden</Text>
+        <Calendar
+          style={styles.calendar}
+          hideDaysOutOfInterval
+          current={INITIAL_DATE}
+          minDate={getDate(-6)}
+          maxDate={getDate(6)}
+          disableAllTouchEventsForDisabledDays
+        />
+      </Fragment>
+    );
+  };
+
   const renderCalendarWithMarkedDatesAndHiddenArrows = () => {
     return (
       <Fragment>
@@ -501,6 +517,7 @@ const CalendarScreen = () => {
         {renderCalendarWithSelectableDate()}
         {renderCalendarWithWeekNumbers()}
         {renderCalendarWithMinAndMaxDates()}
+        {renderCalendarWithDaysOutsideIntervalHidden()}
         {renderCalendarWithCustomDay()}
         {renderCalendarWithInactiveDays()}
         {renderCalendarWithCustomHeaderTitle()}

--- a/example/src/screens/timelineCalendarScreen.tsx
+++ b/example/src/screens/timelineCalendarScreen.tsx
@@ -34,7 +34,8 @@ export default class TimelineCalendarScreen extends Component {
     [`${getDate(4)}`]: {marked: true}
   };
 
-  onDateChanged = (date: string) => {
+  onDateChanged = (date: string, source: string) => {
+    console.log('TimelineCalendarScreen onDateChanged: ', date, source);
     this.setState({currentDate: date});
   };
 

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -7,7 +7,7 @@ import {View, ViewStyle, StyleProp} from 'react-native';
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 
 import constants from '../commons/constants';
-import {page, isGTE, isLTE, sameMonth} from '../dateutils';
+import {page, isGTE, isLTE, sameMonth, isDateNotInRange} from '../dateutils';
 import {xdateToData, parseDate, toMarkingFormat} from '../interface';
 import {getState} from '../day-state-manager';
 import {extractHeaderProps, extractDayProps} from '../componentUpdater';
@@ -42,6 +42,8 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   /** Do not show days of other months in month page */
   hideExtraDays?: boolean;
   /** Always show six weeks on each month (only when hideExtraDays = false) */
+  hideDaysOutOfInterval?: boolean;
+  /** Always hide days when outside of the min/max date interval (only when min/max date !== undefined) */
   showSixWeeks?: boolean;
   /** Handler which gets executed on day press */
   onDayPress?: (date: DateData) => void;
@@ -86,6 +88,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
     disableMonthChange,
     enableSwipeMonths,
     hideExtraDays,
+    hideDaysOutOfInterval,
     firstDay,
     showSixWeeks,
     displayLoadingIndicator,
@@ -196,7 +199,9 @@ const Calendar = (props: CalendarProps & ContextProp) => {
     if (!sameMonth(day, currentMonth) && hideExtraDays) {
       return <View key={id} style={style.current.emptyDayContainer}/>;
     }
-
+    if (minDate && maxDate && isDateNotInRange(day, minDate, maxDate) && hideDaysOutOfInterval) {
+      return <View key={id} style={style.current.emptyDayContainer}/>;
+    }
     const dateString = toMarkingFormat(day);
     const isControlled = isEmpty(props.context);
 
@@ -311,6 +316,7 @@ Calendar.propTypes = {
   maxDate: PropTypes.string,
   markedDates: PropTypes.object,
   hideExtraDays: PropTypes.bool,
+  hideDaysOutOfInterval: PropTypes.bool,
   showSixWeeks: PropTypes.bool,
   onDayPress: PropTypes.func,
   onDayLongPress: PropTypes.func,

--- a/src/calendar/style.ts
+++ b/src/calendar/style.ts
@@ -17,6 +17,10 @@ export default function getStyle(theme: Theme = {}) {
     emptyDayContainer: {
       flex: 1
     },
+    hiddenDayContainer: {
+      width: 0,
+      height: 0,
+    },
     monthView: {
       backgroundColor: appStyle.calendarBackground
     },

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -7,6 +7,7 @@ const isAndroid = Platform.OS === 'android';
 const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
+const isAndroidRTL = isAndroid && isRTL;
 
 export default {
   screenWidth,
@@ -14,5 +15,6 @@ export default {
   isRTL,
   isAndroid,
   isIOS,
-  isTablet
+  isTablet,
+  isAndroidRTL
 };

--- a/src/expandableCalendar/AgendaListsCommon.tsx
+++ b/src/expandableCalendar/AgendaListsCommon.tsx
@@ -1,0 +1,54 @@
+import isEqual from 'lodash/isEqual';
+import React from 'react';
+import {DefaultSectionT, SectionListProps, Text, TextProps, ViewStyle} from 'react-native';
+import {Theme} from '../types';
+
+export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> {
+  /** Specify theme properties to override specific styles for calendar parts */
+  theme?: Theme;
+  /** day format in section title. Formatting values: http://arshaw.com/xdate/#Formatting */
+  dayFormat?: string;
+  /** a function to custom format the section header's title */
+  dayFormatter?: (arg0: string) => string;
+  /** whether to use moment.js for date string formatting
+   * (remember to pass 'dayFormat' with appropriate format, like 'dddd, MMM D') */
+  useMoment?: boolean;
+  /** whether to mark today's title with the "Today, ..." string. Default = true */
+  markToday?: boolean;
+  /** style passed to the section view */
+  sectionStyle?: ViewStyle;
+  /** whether to block the date change in calendar (and calendar context provider) when agenda scrolls */
+  avoidDateUpdates?: boolean;
+  /** offset scroll to section */
+  viewOffset?: number;
+  /** enable scrolling the agenda list to the next date with content when pressing a day without content */
+  scrollToNextEvent?: boolean;
+  /**
+   * @experimental
+   * If defined, uses InfiniteList instead of SectionList. This feature is experimental and subject to change.
+   */
+  infiniteListProps?: {
+    itemHeight?: number;
+    titleHeight?: number;
+    visibleIndicesChangedDebounce?: number;
+    renderFooter?: () => React.ReactElement | null;
+  };
+}
+
+interface AgendaSectionHeaderProps {
+  title?: string;
+  onLayout?: TextProps['onLayout'];
+  style: TextProps['style'];
+}
+
+function areTextPropsEqual(prev: AgendaSectionHeaderProps, next: AgendaSectionHeaderProps): boolean {
+  return isEqual(prev.style, next.style) && prev.title === next.title;
+}
+
+export const AgendaSectionHeader = React.memo((props: AgendaSectionHeaderProps) => {
+  return (
+    <Text allowFontScaling={false} style={props.style} onLayout={props.onLayout}>
+      {props.title}
+    </Text>
+  );
+}, areTextPropsEqual);

--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -18,7 +18,6 @@ import {useDidUpdate} from '../../hooks';
 
 export const NUMBER_OF_PAGES = 6;
 const NUM_OF_ITEMS = NUMBER_OF_PAGES * 2 + 1; // NUMBER_OF_PAGES before + NUMBER_OF_PAGES after + current
-const APPLY_ANDROID_FIX = constants.isAndroid && constants.isRTL;
 
 export interface WeekCalendarProps extends CalendarListProps {
   /** whether to have shadow/elevation for the calendar */
@@ -70,14 +69,15 @@ const WeekCalendar = (props: WeekCalendarProps) => {
           }) :
           sameWeek(item, date, firstDay));
       if (pageIndex !== currentIndex.current) {
+        const adjustedIndexFrScroll = constants.isAndroidRTL ? NUM_OF_ITEMS - 1 - pageIndex : pageIndex;
         if (pageIndex >= 0) {
-          visibleWeek.current = items.current[pageIndex];
-          currentIndex.current = pageIndex;
+          visibleWeek.current = items.current[adjustedIndexFrScroll];
+          currentIndex.current = adjustedIndexFrScroll;
         } else {
           visibleWeek.current = date;
           currentIndex.current = NUMBER_OF_PAGES;
         }
-        pageIndex <= 0 ? onEndReached() : list?.current?.scrollToIndex({index: pageIndex, animated: false});
+        pageIndex <= 0 ? onEndReached() : list?.current?.scrollToIndex({index: adjustedIndexFrScroll, animated: false});
       }
     }
   }, [date, updateSource]);
@@ -179,7 +179,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
     const currItems = items.current;
     const newDate = viewableItems[0]?.item;
     if (newDate !== visibleWeek.current) {
-      if (APPLY_ANDROID_FIX) {
+      if (constants.isAndroidRTL) {
         //in android RTL the item we see is the one in the opposite direction
         const newDateOffset = -1 * (NUMBER_OF_PAGES - currItems.indexOf(newDate));
         const adjustedNewDate = currItems[NUMBER_OF_PAGES - newDateOffset];

--- a/src/expandableCalendar/__test__/index.spec.ts
+++ b/src/expandableCalendar/__test__/index.spec.ts
@@ -243,8 +243,8 @@ describe('ExpandableCalendar', () => {
       beforeEach(() => {
         driver.render();
       });
-      it.each([[Direction.LEFT], [Direction.RIGHT]])(`should call onDateChanged to next week first day when pressing %s arrow`, (direction) => {
-        const currentDay = today.getUTCDay();
+      it.each([['last', Direction.LEFT], ['next', Direction.RIGHT]])(`should call onDateChanged to %s week first day when pressing %s arrow`, (direction) => {
+        const currentDay = today.getDay();
         const expectedDate = today.clone().addDays(direction === Direction.LEFT ? - (currentDay + 7) : (7 - currentDay));
         driver.pressOnHeaderArrow({left: direction === Direction.LEFT});
         expect(onDateChanged).toHaveBeenCalledWith(toMarkingFormat(expectedDate), UpdateSources.PAGE_SCROLL);
@@ -259,7 +259,7 @@ describe('ExpandableCalendar', () => {
 
       it('should fetch next weeks when in last week of the list', () => {
         times(NUMBER_OF_PAGES + 1, () => driver.pressOnHeaderArrow({left: false}));
-        const currentDay = today.getUTCDay();
+        const currentDay = today.getDay();
         const expectedDate = today.clone().addDays(7 * (NUMBER_OF_PAGES + 1) - currentDay);
         const day = driver.getWeekDay(toMarkingFormat(expectedDate));
         expect(day).toBeDefined();
@@ -269,7 +269,6 @@ describe('ExpandableCalendar', () => {
         const endOfMonth = new XDate(today.getFullYear(), today.getMonth() + 1, 0, 0, 0 ,0 , 0, true);
         const diff = Math.ceil(((endOfMonth.getUTCDate() + 1) - today.getUTCDate()) / 7) + ((today.getUTCDay() > endOfMonth.getUTCDay()) ? 1 : 0);
         const expectedDate = today.clone().setDate(today.getDate() + 7 * diff - today.getDay());
-        console.log(diff, endOfMonth, expectedDate);
         times(diff, () => driver.pressOnHeaderArrow({left: false}));
         expect(onMonthChange).toHaveBeenCalledWith(xdateToData(expectedDate), UpdateSources.PAGE_SCROLL);
       });

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -5,23 +5,18 @@ import map from 'lodash/map';
 import isFunction from 'lodash/isFunction';
 import isUndefined from 'lodash/isUndefined';
 import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
 
 import XDate from 'xdate';
 
 import React, {useCallback, useContext, useEffect, useMemo, useRef} from 'react';
 import {
-  Text,
   SectionList,
-  SectionListProps,
   DefaultSectionT,
   SectionListData,
-  ViewStyle,
   NativeSyntheticEvent,
   NativeScrollEvent,
   LayoutChangeEvent,
   ViewToken,
-  TextProps
 } from 'react-native';
 
 import {useDidUpdate} from '../hooks';
@@ -29,48 +24,16 @@ import {getMoment} from '../momentResolver';
 import {isToday, isGTE, sameDate} from '../dateutils';
 import {parseDate} from '../interface';
 import {getDefaultLocale} from '../services';
-import {Theme} from '../types';
 import {UpdateSources, todayString} from './commons';
 import constants from '../commons/constants';
 import styleConstructor from './style';
 import Context from './Context';
 import InfiniteAgendaList from './infiniteAgendaList';
+import {AgendaListProps, AgendaSectionHeader} from './AgendaListsCommon';
 
 const viewabilityConfig = {
   itemVisiblePercentThreshold: 20 // 50 means if 50% of the item is visible
 };
-
-export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> {
-  /** Specify theme properties to override specific styles for calendar parts */
-  theme?: Theme;
-  /** day format in section title. Formatting values: http://arshaw.com/xdate/#Formatting */
-  dayFormat?: string;
-  /** a function to custom format the section header's title */
-  dayFormatter?: (arg0: string) => string;
-  /** whether to use moment.js for date string formatting
-   * (remember to pass 'dayFormat' with appropriate format, like 'dddd, MMM D') */
-  useMoment?: boolean;
-  /** whether to mark today's title with the "Today, ..." string. Default = true */
-  markToday?: boolean;
-  /** style passed to the section view */
-  sectionStyle?: ViewStyle;
-  /** whether to block the date change in calendar (and calendar context provider) when agenda scrolls */
-  avoidDateUpdates?: boolean;
-  /** offset scroll to section */
-  viewOffset?: number;
-  /** enable scrolling the agenda list to the next date with content when pressing a day without content */
-  scrollToNextEvent?: boolean;
-  /**
-   * @experimental
-   * If defined, uses InfiniteList instead of SectionList. This feature is experimental and subject to change.
-   */
-  infiniteListProps?: {
-    itemHeight?: number;
-    titleHeight?: number;
-    visibleIndicesChangedDebounce?: number;
-    renderFooter?: () => React.ReactElement | null;
-  };
-}
 
 /**
  * @description: AgendaList component
@@ -283,24 +246,6 @@ const AgendaList = (props: AgendaListProps) => {
   //   return {length: constants.screenWidth, offset: constants.screenWidth * index, index};
   // }
 };
-
-interface AgendaSectionHeaderProps {
-  title?: string;
-  onLayout?: TextProps['onLayout'];
-  style: TextProps['style'];
-}
-
-function areTextPropsEqual(prev: AgendaSectionHeaderProps, next: AgendaSectionHeaderProps): boolean {
-  return isEqual(prev.style, next.style) && prev.title === next.title;
-}
-
-export const AgendaSectionHeader = React.memo((props: AgendaSectionHeaderProps) => {
-  return (
-    <Text allowFontScaling={false} style={props.style} onLayout={props.onLayout}>
-      {props.title}
-    </Text>
-  );
-}, areTextPropsEqual);
 
 export default AgendaList;
 

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -22,7 +22,7 @@ import Context from './Context';
 import constants from "../commons/constants";
 import {parseDate} from "../interface";
 import {LayoutProvider} from "recyclerlistview/dist/reactnative/core/dependencies/LayoutProvider";
-import {AgendaListProps, AgendaSectionHeader} from "./agendaList";
+import {AgendaSectionHeader, AgendaListProps} from "./AgendaListsCommon";
 
 /**
  * @description: AgendaList component that use InfiniteList to improve performance

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type {ExpandableCalendarProps} from './expandableCalendar';
 export {default as WeekCalendar} from './expandableCalendar/WeekCalendar/new';
 export type {WeekCalendarProps} from './expandableCalendar/WeekCalendar';
 export {default as AgendaList} from './expandableCalendar/agendaList';
-export type {AgendaListProps} from './expandableCalendar/agendaList';
+export type {AgendaListProps} from './expandableCalendar/AgendaListsCommon';
 export {default as CalendarContext} from './expandableCalendar/Context';
 export {default as CalendarProvider} from './expandableCalendar/Context/Provider';
 export type {CalendarContextProviderProps} from './expandableCalendar/Context/Provider';

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -22,6 +22,7 @@ export interface InfiniteListProps
   onReachNearEdge?: (pageIndex: number) => void;
   onReachNearEdgeThreshold?: number;
   initialPageIndex?: number;
+  initialOffset?: number;
   scrollViewProps?: ScrollViewProps;
   reloadPages?: (pageIndex: number) => void;
   positionIndex?: number;
@@ -43,6 +44,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     onReachNearEdge,
     onReachNearEdgeThreshold,
     initialPageIndex = 0,
+    initialOffset,
     extendedState,
     scrollViewProps,
     positionIndex = 0,
@@ -68,6 +70,9 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
       }
     )
   );
+  const shouldUseAndroidRTLFix = useMemo(() => {
+    return constants.isAndroidRTL && isHorizontal;
+  }, []);
 
   const listRef = useCombinedRefs(ref);
   const pageIndex = useRef<number>();
@@ -82,7 +87,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     }
 
     setTimeout(() => {
-      const x = isHorizontal ? Math.floor(data.length / 2) * pageWidth : 0;
+      const x = isHorizontal ? constants.isAndroidRTL ? Math.floor(data.length / 2) + 1 : Math.floor(data.length / 2) * pageWidth : 0;
       const y = isHorizontal ? 0 : positionIndex * pageHeight;
       // @ts-expect-error
       listRef.current?.scrollToOffset?.(x, y, false);
@@ -93,9 +98,10 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     (event, offsetX, offsetY) => {
       reloadPagesDebounce?.cancel();
 
-      const {x, y} = event.nativeEvent.contentOffset;
+      const contentOffset = event.nativeEvent.contentOffset;
+      const y = contentOffset.y;
+      const x = shouldUseAndroidRTLFix ? (pageWidth * data.length - contentOffset.x) : contentOffset.x;
       const newPageIndex = Math.round(isHorizontal ? x / pageWidth : y / pageHeight);
-
       if (pageIndex.current !== newPageIndex) {
         if (pageIndex.current !== undefined) {
           onPageChange?.(newPageIndex, pageIndex.current, {scrolledByUser: scrolledByUser.current});
@@ -169,11 +175,13 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
       // @ts-expect-error
       ref={listRef}
       isHorizontal={isHorizontal}
+      disableRecycling={shouldUseAndroidRTLFix}
       rowRenderer={renderItem}
       dataProvider={dataProvider}
       layoutProvider={layoutProvider ?? _layoutProvider.current}
       extendedState={extendedState}
-      initialRenderIndex={initialPageIndex}
+      initialRenderIndex={initialOffset ? undefined : initialPageIndex}
+      initialOffset={initialOffset}
       renderAheadOffset={5 * pageWidth}
       onScroll={_onScroll}
       style={style}

--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -2,14 +2,15 @@ import throttle from 'lodash/throttle';
 import flatten from 'lodash/flatten';
 import dropRight from 'lodash/dropRight';
 
-import React, {useCallback, useContext, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 
 import {isToday, generateDay} from '../dateutils';
 import InfiniteList from '../infinite-list';
 import Context from '../expandableCalendar/Context';
 import {UpdateSources} from '../expandableCalendar/commons';
 import Timeline, {TimelineProps} from '../timeline/Timeline';
-import useTimelinePages, {INITIAL_PAGE, NEAR_EDGE_THRESHOLD} from './useTimelinePages';
+import useTimelinePages, {INITIAL_PAGE, NEAR_EDGE_THRESHOLD, PAGES_COUNT} from './useTimelinePages';
+import constants from '../commons/constants';
 
 export interface TimelineListRenderItemInfo {
   item: string;
@@ -73,6 +74,9 @@ const TimelineList = (props: TimelineListProps) => {
     prevDate.current = date;
   }, [updateSource]);
 
+  const initialOffset = useMemo(() =>
+  constants.isAndroidRTL ? constants.screenWidth * (PAGES_COUNT - INITIAL_PAGE - 1) : constants.screenWidth * INITIAL_PAGE, []);
+
   useEffect(() => {
     if (date !== prevDate.current) {
       scrollToCurrentDate(date);
@@ -93,7 +97,7 @@ const TimelineList = (props: TimelineListProps) => {
 
   const onPageChange = useCallback(
     throttle((pageIndex: number) => {
-      const newDate = pages[pageIndex];
+      const newDate = pages[constants.isAndroidRTL ? pageIndex - 1 : pageIndex];
       if (newDate !== prevDate.current) {
         setDate(newDate, UpdateSources.LIST_DRAG);
       }
@@ -140,7 +144,7 @@ const TimelineList = (props: TimelineListProps) => {
         <>
           <Timeline {..._timelineProps}/>
           {/* NOTE: Keeping this for easy debugging */}
-          {/* <Text style={{position: 'absolute'}}>{item}</Text> */}
+          {/* <Text style={{position: 'absolute'}}>{item}</Text>*/}
         </>
       );
     },
@@ -158,7 +162,7 @@ const TimelineList = (props: TimelineListProps) => {
       onReachNearEdgeThreshold={NEAR_EDGE_THRESHOLD}
       onScroll={onScroll}
       extendedState={{todayEvents: events[date], pages}}
-      initialPageIndex={INITIAL_PAGE}
+      initialOffset={initialOffset}
       scrollViewProps={{
         onMomentumScrollEnd
       }}

--- a/src/timeline-list/useTimelinePages.ts
+++ b/src/timeline-list/useTimelinePages.ts
@@ -48,7 +48,7 @@ const UseTimelinePages = ({date, listRef, numberOfDays}: UseTimelinePagesProps) 
   }, []);
 
   const scrollToPage = (pageIndex: number) => {
-    listRef.current?.scrollToOffset(pageIndex * constants.screenWidth, 0, false);
+    listRef.current?.scrollToOffset(constants.isAndroidRTL ? ((PAGES_COUNT - 1 - pageIndex) * constants.screenWidth) : (pageIndex * constants.screenWidth), 0, false);
   };
 
   const resetPages = (date: string) => {


### PR DESCRIPTION
You can now hide days that's outside the min/max date interval.
Usefull to reduce the height of the Calendar component and to display only required days.

Documentation & example added.